### PR TITLE
feat: implement JWT-based authentication with stateless security configuration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -42,7 +42,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.5.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -48,6 +48,11 @@
 			<version>4.5.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.17.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/backend/src/main/java/com/taskman/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/taskman/backend/config/SecurityConfig.java
@@ -1,5 +1,9 @@
 package com.taskman.backend.config;
 
+import com.taskman.backend.security.Jwt;
+import com.taskman.backend.security.JwtAuthenticationFilter;
+import com.taskman.backend.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,16 +13,29 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.NullSecurityContextRepository;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    private final Jwt jwt;
+
+    @Autowired
+    public SecurityConfig(CustomUserDetailsService customUserDetailsService, Jwt jwt) {
+        this.customUserDetailsService = customUserDetailsService;
+        this.jwt = jwt;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,7 +46,10 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST,"/taskman/api/users").permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .securityContext((context) -> context.securityContextRepository(new NullSecurityContextRepository()))
+                .addFilterBefore(new JwtAuthenticationFilter(jwt, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/taskman/backend/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/taskman/backend/controller/AuthenticationController.java
@@ -1,7 +1,10 @@
 package com.taskman.backend.controller;
 
 import com.taskman.backend.dto.LoginRequest;
+import com.taskman.backend.security.Jwt;
 import com.taskman.backend.service.AuthenticationService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,21 +22,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthenticationController {
 
     private final AuthenticationService authenticationService;
+    private final Jwt jwt;
 
     @Autowired
-    public AuthenticationController(AuthenticationService authenticationService) {
+    public AuthenticationController(AuthenticationService authenticationService, Jwt jwt) {
         this.authenticationService = authenticationService;
+        this.jwt = jwt;
     }
 
     /**
      * Authenticates a login request.
+     * @param request The Http request.
+     * @param response The Http response.
      * @param loginRequest The login request of a client.
      * @return The login authentication result.
      */
     @PostMapping("/login")
-    public ResponseEntity<?> login (@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<?> login (HttpServletRequest request, HttpServletResponse response, @RequestBody LoginRequest loginRequest) {
         try {
-            authenticationService.authenticate(loginRequest.username(), loginRequest.password());
+            Long userId = authenticationService.authenticate(loginRequest.username(), loginRequest.password());
+            jwt.makeToken(request, response, String.valueOf(userId));
 
             return ResponseEntity.ok("Login successful");
         } catch (BadCredentialsException ex) {

--- a/backend/src/main/java/com/taskman/backend/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/taskman/backend/security/CustomUserDetails.java
@@ -1,0 +1,71 @@
+package com.taskman.backend.security;
+
+import com.taskman.backend.entity.User;
+import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Custom implementation of {@link UserDetails} for
+ * storing core user information.
+ */
+public class CustomUserDetails implements UserDetails, CredentialsContainer {
+
+    private Long id;
+    private String username;
+    private String password;
+
+    public CustomUserDetails(User user) {
+        this.id = user.getId();
+        this.username = user.getUsername();
+        this.password = user.getHashPassword();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+
+    @Override
+    public void eraseCredentials() {
+        this.password = null;
+    }
+}

--- a/backend/src/main/java/com/taskman/backend/security/Jwt.java
+++ b/backend/src/main/java/com/taskman/backend/security/Jwt.java
@@ -1,0 +1,95 @@
+package com.taskman.backend.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+/**
+ * Component class handling JSON Web Token (JWT) creation,
+ * extraction, and verification logic.
+ */
+@Component
+public class Jwt {
+
+    private final String secret;
+    private final int expirationMin;
+    private final String cookieName;
+
+    private final JWTVerifier verifier;
+
+    @Autowired
+    public Jwt(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration-min}") int expirationMin,
+            @Value("${jwt.cookie-name}") String cookieName
+    ) {
+        this.verifier = JWT.require(Algorithm.HMAC256(secret)).build();
+        this.secret = secret;
+        this.expirationMin = expirationMin;
+        this.cookieName = cookieName;
+    }
+
+    public String extract(HttpServletRequest request) {
+        Cookie cookie = WebUtils.getCookie(request, cookieName);
+        if (cookie != null) {
+            return cookie.getValue();
+        } else {
+            return null;
+        }
+    }
+
+    public Boolean verify(String token) {
+        try {
+            verifier.verify(token);
+            return Boolean.TRUE;
+        } catch (JWTVerificationException e) {
+            return Boolean.FALSE;
+        }
+    }
+
+    public String getSubject(String token) {
+        return JWT.decode(token).getSubject();
+    }
+
+    public String create(String userIdentify) {
+        return JWT.create()
+                .withSubject(String.valueOf(userIdentify))
+                .withIssuedAt(new Date())
+                .withExpiresAt(
+                        Date.from(
+                                LocalDateTime.now()
+                                        .plusMinutes(expirationMin)
+                                        .atZone(ZoneId.systemDefault())
+                                        .toInstant()))
+                .sign(Algorithm.HMAC256(secret));
+    }
+
+    private Cookie buildJwtCookiePojo(HttpServletRequest request, String userIdentify) {
+        String contextPath = request.getContextPath();
+        String cookiePath = StringUtils.isNotEmpty(contextPath) ? contextPath : "/";
+        Cookie cookie = new Cookie(cookieName, create(userIdentify));
+        cookie.setPath(cookiePath);
+        cookie.setMaxAge(expirationMin * 60);
+        cookie.setSecure(request.isSecure());
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+
+    public void makeToken(
+            HttpServletRequest request, HttpServletResponse response, String userIdentify) {
+        response.addCookie(buildJwtCookiePojo(request, userIdentify));
+    }
+}

--- a/backend/src/main/java/com/taskman/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/taskman/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.taskman.backend.security;
+
+import com.taskman.backend.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Filter class implementing JWT authentication filter logic.
+ */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final Jwt jwt;
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    public JwtAuthenticationFilter(Jwt jwt, CustomUserDetailsService customUserDetailsService) {
+        this.jwt = jwt;
+        this.customUserDetailsService = customUserDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwt.extract(request);
+        if (StringUtils.isNotEmpty(token) && jwt.verify(token)) {
+            try {
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(jwt.getSubject(token));
+                JwtAuthenticationToken authenticated = JwtAuthenticationToken.authenticated(userDetails, token, userDetails.getAuthorities());
+                authenticated.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authenticated);
+            } catch (Exception e) {
+                System.out.println(e);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/taskman/backend/security/JwtAuthenticationToken.java
+++ b/backend/src/main/java/com/taskman/backend/security/JwtAuthenticationToken.java
@@ -1,0 +1,55 @@
+package com.taskman.backend.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.SpringSecurityCoreVersion;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.io.Serial;
+import java.util.Collection;
+
+/**
+ * A JWT Authentication Token implementation of {@link AbstractAuthenticationToken}
+ * for representing a JWT-based authenticated user.
+ */
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    @Serial private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
+
+    private final Object principal;
+
+    private String credentials;
+
+    public JwtAuthenticationToken(Object principal, String credentials) {
+        super(null);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(true);
+    }
+
+    public static JwtAuthenticationToken unauthenticated(String userIdentify, String token) {
+        return new JwtAuthenticationToken(userIdentify, token);
+    }
+
+    public static JwtAuthenticationToken authenticated(
+            UserDetails principal, String token, Collection<? extends GrantedAuthority> authorities) {
+        return new JwtAuthenticationToken(principal, token, authorities);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/backend/src/main/java/com/taskman/backend/service/AuthenticationService.java
+++ b/backend/src/main/java/com/taskman/backend/service/AuthenticationService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -29,13 +30,18 @@ public class AuthenticationService {
      * @return Authenticated user identifier.
      */
     public Long authenticate(String username, String password) {
-        Authentication authenticationRequest = UsernamePasswordAuthenticationToken.unauthenticated(username, password);
-        Authentication authenticationResponse = this.authenticationManager.authenticate(authenticationRequest);
+        try {
+            Authentication authenticationRequest = UsernamePasswordAuthenticationToken.unauthenticated(username, password);
+            Authentication authenticationResponse = this.authenticationManager.authenticate(authenticationRequest);
 
-        SecurityContext securityContext =  SecurityContextHolder.getContext();
-        securityContext.setAuthentication(authenticationResponse);
+            SecurityContext securityContext =  SecurityContextHolder.getContext();
+            securityContext.setAuthentication(authenticationResponse);
 
-        CustomUserDetails user = (CustomUserDetails) authenticationResponse.getPrincipal();
-        return user.getId();
+            CustomUserDetails user = (CustomUserDetails) authenticationResponse.getPrincipal();
+            return user.getId();
+        } catch (AuthenticationException ex) {
+            System.out.println("AUTHENTICATION ERROR: " + ex.getMessage());
+            throw ex;
+        }
     }
 }

--- a/backend/src/main/java/com/taskman/backend/service/AuthenticationService.java
+++ b/backend/src/main/java/com/taskman/backend/service/AuthenticationService.java
@@ -1,5 +1,6 @@
 package com.taskman.backend.service;
 
+import com.taskman.backend.security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -25,12 +26,16 @@ public class AuthenticationService {
      * Authenticates a user with the username and password.
      * @param username The user's username.
      * @param password The user's raw password.
+     * @return Authenticated user identifier.
      */
-    public void authenticate(String username, String password) {
+    public Long authenticate(String username, String password) {
         Authentication authenticationRequest = UsernamePasswordAuthenticationToken.unauthenticated(username, password);
         Authentication authenticationResponse = this.authenticationManager.authenticate(authenticationRequest);
 
         SecurityContext securityContext =  SecurityContextHolder.getContext();
         securityContext.setAuthentication(authenticationResponse);
+
+        CustomUserDetails user = (CustomUserDetails) authenticationResponse.getPrincipal();
+        return user.getId();
     }
 }

--- a/backend/src/main/java/com/taskman/backend/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/taskman/backend/service/CustomUserDetailsService.java
@@ -2,6 +2,7 @@ package com.taskman.backend.service;
 
 import com.taskman.backend.entity.User;
 import com.taskman.backend.repository.UserRepository;
+import com.taskman.backend.security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -21,11 +22,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username).orElseThrow(() -> new UsernameNotFoundException("User not found"));
-
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getUsername())
-                .password(user.getHashPassword())
-                .roles("USER")
-                .build();
+        return new CustomUserDetails(user);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,3 +11,8 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# JWT Configuration
+jwt.secret=${JWT_SECRET:secret}
+jwt.expiration-min=${JWT_EXPIRATION_MIN:60}
+jwt.cookie-name=${JWT_COOKIE_NAME:jwt}


### PR DESCRIPTION
This PR introduces **_JWT-based authentication_** for _**Taskman**_, enabling stateless session management and secure login handling. 
### Major Changes
- Implemented JWT-based authentication using `CustomUserDetails` and `CustomUserDetailsService`.
- On successful login, a JWT is generated and stored in an HTTP-only cookie.
- Added `JwtAuthenticationFilter` to validate JWT and authenticate users on each request.
- Configured Spring Security to be stateless (`SessionCreationPolicy.STATELESS`) and using a `NullSecurityContextRepository` as the `SecurityContextRepository`.
- Ensured cookies are only sent on successful login and verified via token signature and expiry.
