### PR TITLE
feat: add create card functionality with connection to Card creation API

### DIFF
--- a/frontend/src/app/(main)/board/[boardId]/[slug]/page.js
+++ b/frontend/src/app/(main)/board/[boardId]/[slug]/page.js
@@ -1,6 +1,8 @@
 "use client";
 
+import BoardAddCardButton from "@/components/board/board-add-card-button";
 import { BoardAddListButton } from "@/components/board/board-add-list-button";
+import BoardCardsDisplay from "@/components/board/board-cards-display";
 import { Card } from "@/components/ui/card";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -41,12 +43,15 @@ export default function BoardPage() {
       {lists.map((list) => (
         <Card
           key={list.id}
-          className="bg-card border-secondary flex h-fit w-[300px] cursor-pointer flex-row rounded-lg p-3 transition hover:opacity-90"
+          className="bg-card border-secondary flex h-fit w-[300px] cursor-pointer flex-col rounded-lg p-3 transition hover:opacity-90"
         >
           <p className="font-bold">{list.title}</p>
+          {/* List of Cards from List */}
+          <BoardCardsDisplay listId={list.id} />
+          <BoardAddCardButton listId={list.id} />
         </Card>
       ))}
-      {/* Add List  */}
+      {/* Add List */}
       <BoardAddListButton boardId={boardId} />
     </div>
   );

--- a/frontend/src/components/board/board-add-card-button.jsx
+++ b/frontend/src/components/board/board-add-card-button.jsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card } from "../ui/card";
+
+export default function BoardAddCardButton({
+  listId,
+  buttonText = "Add a card",
+  confirmText = "Add card",
+  placeholder = "Enter card name...",
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [title, setTitle] = useState("");
+  const formRef = useRef(null);
+  const inputRef = useRef(null);
+
+  // Handle clicks outside the component
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (formRef.current && !formRef.current.contains(event.target)) {
+        setIsEditing(false);
+        setTitle("");
+      }
+    }
+
+    if (isEditing) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isEditing]);
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (title.trim()) {
+      setTitle("");
+      setIsEditing(false);
+    }
+
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/taskman/api/cards`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({ title: title, listId: listId }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to create card.");
+      }
+
+      setTitle("");
+      alert("Card created successfully.");
+    } catch (err) {
+      console.log("Error creating card: ", err);
+    }
+  };
+
+  if (!isEditing) {
+    return (
+      <Card
+        className="hover:bg-primary-foreground flex h-fit w-full cursor-pointer flex-row rounded-lg border-0 p-2 transition hover:opacity-90"
+        onClick={() => setIsEditing(true)}
+      >
+        <Plus />
+        {buttonText}
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      ref={formRef}
+      className="flex h-fit w-full cursor-pointer flex-row border-0 p-2 transition hover:opacity-90"
+    >
+      <form onSubmit={handleSubmit}>
+        <Input
+          ref={inputRef}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={placeholder}
+          className="mb-2"
+        />
+        <div className="flex items-center gap-2">
+          <Button size="sm" type="submit" disabled={!title.trim()}>
+            {confirmText}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            type="button"
+            onClick={() => {
+              setIsEditing(false);
+              setTitle("");
+            }}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/src/components/board/board-cards-display.jsx
+++ b/frontend/src/components/board/board-cards-display.jsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card } from "../ui/card";
+
+export default function BoardCardsDisplay({ listId }) {
+  const [cards, setCards] = useState([]);
+
+  useEffect(() => {
+    const fetchCards = async () => {
+      try {
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/taskman/api/cards/list/${listId}`,
+          {
+            credentials: "include",
+          },
+        );
+
+        if (!res.ok) throw new Error("Failed to fetch cards");
+        const data = await res.json();
+
+        setCards(data);
+      } catch (err) {
+        console.log("Error fetching cards", err);
+      }
+    };
+
+    fetchCards();
+  }, []);
+
+  if (cards.length == 0) return null;
+
+  return (
+    <div className="flex flex-col space-y-2">
+      {cards.map((card) => (
+        <Card
+          key={card.id}
+          className="bg-primary-foreground border-secondary flex h-fit w-full cursor-pointer flex-row rounded-lg p-2 transition hover:opacity-90"
+        >
+          <p>{card.title}</p>
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR integrates the create card functionality in the Board page of the frontend. 

### Major Frontend Changes
- Board Page
![image](https://github.com/user-attachments/assets/cf3c79a5-0349-4b49-b9d6-be1fa604b0b6)

   - Add user interface for displaying cards of a list in a board.
   - Connect Card creation API with the Add card button in the Board page.

**_Notes:_**
- The Board Page does not reflect the real-time changes in the state of the Board. In the future, WebSockets will be integrated in the frontend and backend of the project to reflect real-time changes in the state of the entities managed in the project.